### PR TITLE
Update licence on python3-zoloto to be BSD-3-Clause

### DIFF
--- a/sources/meta-srobo/recipes-devtools/python/python3-zoloto_0.8.0.bb
+++ b/sources/meta-srobo/recipes-devtools/python/python3-zoloto_0.8.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "A fiducial marker system powered by OpenCV - Supports ArUco and April"
 DESCRIPTION = "A fiducial marker system powered by OpenCV - Supports ArUco and April"
 HOMEPAGE = "https://github.com/RealOrangeOne/zoloto"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bfd7580e6f0deacd183d33dd0ee386d8"
 
 SRC_URI[sha256sum] = "885678a60cad8e8ed57d857a9c219b36f13f0e351124dcc6db3485050cc6f16f"


### PR DESCRIPTION
In Kirkstone, we need to be more specific than just BSD for this licence

Fixes #6 