### PR TITLE
servohack: Only cycle USB Power when usercode drive is removed

### DIFF
--- a/sources/meta-srobo/recipes-robot/servohack/servohack/servohack.py
+++ b/sources/meta-srobo/recipes-robot/servohack/servohack/servohack.py
@@ -50,7 +50,7 @@ class ServoHackConsumer(StateConsumer):
                     if message.code_status is CodeStatus.RUNNING:
                         self._code_started = True
                         LOGGER.info("Code has been started")
-                    elif message.code_status is not CodeStatus.RUNNING and self._code_started:
+                    elif message.code_status is None and self._code_started:
                         LOGGER.info("USB removed, toggling USB lines")
                         # Use USB power per-port power switching to toggle USB Power
                         # More information on the USB Hub Architecture of the Raspberry Pi 4


### PR DESCRIPTION
If we cycle USB power at the end of a usercode program whilst the USB drive is still inserted, it kicks the USB drive out and in, which astdiskd then sees as a new drive insertion and we end up with the robot in a restart loop.

This change means that we cannot restart the code without pulling the USB, although this is always going to have to be the case until PLOD is fixed as we cannot determine the order that the user is going to plug in USB devices.

For example, if the user used a "dumb hub", (no per-port power switching) and plugged in both the usercode drive and servo board, we would be unable to restart the servo board without also power cycling the usercode drive too.