### PR TITLE
Remove Exynos Kernel Modules from Blacklist

### DIFF
--- a/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit.bb
+++ b/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit.bb
@@ -8,7 +8,6 @@ SRC_URI = " \
     file://LICENSE \
     file://10-srobo.rules \
     file://astoria.toml \
-    file://exynos-blacklist.conf \
     file://mount_options.conf \
     "
 
@@ -25,8 +24,6 @@ do_install () {
     chown -R astoria:astoria ${D}/var/srobo/cache/
     install -m 0644 ${WORKDIR}/10-srobo.rules ${D}/usr/lib/udev/rules.d/
     install -m 0644 ${WORKDIR}/astoria.toml ${D}/etc/
-    install -d ${D}/etc/modprobe.d/
-    install -m 0644 ${WORKDIR}/exynos-blacklist.conf ${D}/etc/modprobe.d/
     install -d ${D}/etc/udisks2/
     install -m 0644 ${WORKDIR}/mount_options.conf ${D}/etc/udisks2/
 }

--- a/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit/exynos-blacklist.conf
+++ b/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit/exynos-blacklist.conf
@@ -1,3 +1,0 @@
-blacklist s5p_fimc
-blacklist s5p_jpeg
-blacklist s5p_mfc


### PR DESCRIPTION
These kernel modules are specific to the ODROID and are no longer present in the kernel, or loaded.

Therefore we no longer need to explicitly turn them off.

Fixes #15