### PR TITLE
Disable root login

### DIFF
--- a/sources/meta-srobo/recipes-images/images/srobo-image-robot.bb
+++ b/sources/meta-srobo/recipes-images/images/srobo-image-robot.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 
 inherit core-image
 
-IMAGE_FEATURES += " \
+IMAGE_FEATURES = " \
     ssh-server-openssh \
     package-management \
     "


### PR DESCRIPTION
I think the Core image enables debug-tweaks and passwordless-root
Changing this to '=' from '+=' overrides the default options

Need to check this fully to see if this disabled anything else