### PR TITLE
Fix sudo path

### DIFF
--- a/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit.bb
+++ b/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit.bb
@@ -38,4 +38,6 @@ do_install () {
     install -m 0644 ${WORKDIR}/astoria.toml ${D}/etc/
     install -d ${D}/etc/udisks2/
     install -m 0644 ${WORKDIR}/mount_options.conf ${D}/etc/udisks2/
+    install -d ${D}${sysconfdir}/profile.d/
+    install -m 0755 ${WORKDIR}/srobo.sh ${D}${sysconfdir}/profile.d/
 }

--- a/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit/srobo.sh
+++ b/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit/srobo.sh
@@ -1,0 +1,2 @@
+# Add sbin to the path for non-root users so that root-only commands like shutdown/ip can be used through sudo
+PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin

--- a/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit/srobo.sh
+++ b/sources/meta-srobo/recipes-robot/srobo-kit/srobo-kit/srobo.sh
@@ -1,2 +1,5 @@
 # Add sbin to the path for non-root users so that root-only commands like shutdown/ip can be used through sudo
 PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin
+
+# Stop OpenCV using gstreamer in all sessions
+export OPENCV_VIDEOIO_PRIORITY_GSTREAMER=0


### PR DESCRIPTION
Add sbin locations to PATH. This could alternatively be done by setting `secure_path` in sudoers, but that causes sudo to not use the user's path which is likely to cause unexpected behaviour down the line.

Also defines the OPENCV_VIDEOIO_PRIORITY_GSTREAMER in profile so errors are not printed in interactive python sessions.