### PR TITLE
Fixes from testing

### DIFF
--- a/files/astoria/udisks/mount_options.conf
+++ b/files/astoria/udisks/mount_options.conf
@@ -1,3 +1,3 @@
 [defaults]
-defaults=rw,sync
+defaults=rw
 

--- a/files/python/libraries.txt
+++ b/files/python/libraries.txt
@@ -5,7 +5,7 @@ pandas==2.0.3
 numpy==1.24.4
 pillow==10.0.0
 shapely==2.0.1
-scipy==1.11.2
+scipy==1.10.1
 scikit-learn==1.3.0
 flask==2.3.3
 networkx==3.1

--- a/files/python/requirements.txt
+++ b/files/python/requirements.txt
@@ -1,6 +1,6 @@
 # The python packages required to make the image work
 RPi.GPIO>=0.7.0,<1
-sr-robot3==2024.0.0rc1
+sr-robot3==2024.0.0rc2
 kchd==0.4.1
 astoria==0.11.3
 

--- a/files/python/requirements.txt
+++ b/files/python/requirements.txt
@@ -2,7 +2,7 @@
 RPi.GPIO>=0.7.0,<1
 sr-robot3==2024.0.0rc1
 kchd==0.4.1
-astoria==0.11.2
+astoria==0.11.3
 
 rtui==0.1.1
 


### PR DESCRIPTION
- Correct scipy to support python 3.8-3.11
- Bump Astoria to only use sync writes for logs so saving images is much faster